### PR TITLE
Release 5.6.0

### DIFF
--- a/Examples/YandexMobileAdsExample/YandexMobileAdsExample/MobileMediation/MobileMediationBannerViewController.swift
+++ b/Examples/YandexMobileAdsExample/YandexMobileAdsExample/MobileMediation/MobileMediationBannerViewController.swift
@@ -11,13 +11,18 @@ import YandexMobileAds
 private let adMobAdUnitID = "demo-banner-admob"
 private let mintegralAdUnitID = "demo-banner-mintegral"
 private let myTargetAdUnitID = "demo-banner-mytarget"
+private let chartboostAdUnitID = "demo-banner-chartboost"
+private let adColonyAdUnitID = "demo-banner-adcolony"
 private let yandexAdUnitID = "demo-banner-yandex"
 
 class MobileMediationBannerViewController: UIViewController {
+    
     private let adUnitIDs = [
         (adapter: "AdMob", adUnitID: adMobAdUnitID),
         (adapter: "Mintegral", adUnitID: mintegralAdUnitID),
         (adapter: "MyTarget", adUnitID: myTargetAdUnitID),
+        (adapter: "Chartboost", adUnitID: chartboostAdUnitID),
+        (adapter: "AdColony", adUnitID: adColonyAdUnitID),
         (adapter: "Yandex", adUnitID: yandexAdUnitID)
     ]
 

--- a/Examples/YandexMobileAdsExample/YandexMobileAdsExample/MobileMediation/MobileMediationInterstitialViewController.swift
+++ b/Examples/YandexMobileAdsExample/YandexMobileAdsExample/MobileMediation/MobileMediationInterstitialViewController.swift
@@ -14,6 +14,8 @@ private let ironSourceAdUnitID = "demo-interstitial-ironsource"
 private let mintegralAdUnitID = "demo-interstitial-mintegral"
 private let myTargetAdUnitID = "demo-interstitial-mytarget"
 private let unityAdsAdUnitID = "demo-interstitial-unityads"
+private let chartboostAdUnitID = "demo-interstitial-chartboost"
+private let adColonyAdUnitID = "demo-interstitial-adcolony"
 private let yandexAdUnitID = "demo-interstitial-yandex"
 
 class MobileMediationInterstitialViewController: UIViewController {
@@ -24,6 +26,8 @@ class MobileMediationInterstitialViewController: UIViewController {
         (adapter: "Mintegral", adUnitID: mintegralAdUnitID),
         (adapter: "MyTarget", adUnitID: myTargetAdUnitID),
         (adapter: "UnityAds", adUnitID: unityAdsAdUnitID),
+        (adapter: "Chartboost", adUnitID: chartboostAdUnitID),
+        (adapter: "AdColony", adUnitID: adColonyAdUnitID),
         (adapter: "Yandex", adUnitID: yandexAdUnitID)
     ]
     

--- a/Examples/YandexMobileAdsExample/YandexMobileAdsExample/MobileMediation/MobileMediationRewardedViewController.swift
+++ b/Examples/YandexMobileAdsExample/YandexMobileAdsExample/MobileMediation/MobileMediationRewardedViewController.swift
@@ -14,6 +14,8 @@ private let ironSourceAdUnitID = "demo-rewarded-ironsource"
 private let mintegralAdUnitID = "demo-rewarded-mintegral"
 private let myTargetAdUnitID = "demo-rewarded-mytarget"
 private let unityAdsAdUnitID = "demo-rewarded-unityads"
+private let chartboostAdUnitID = "demo-rewarded-chartboost"
+private let adColonyAdUnitID = "demo-rewarded-adcolony"
 private let yandexAdUnitID = "demo-rewarded-yandex"
 
 class MobileMediationRewardedViewController: UIViewController {
@@ -24,6 +26,8 @@ class MobileMediationRewardedViewController: UIViewController {
         (adapter: "Mintegral", adUnitID: mintegralAdUnitID),
         (adapter: "MyTarget", adUnitID: myTargetAdUnitID),
         (adapter: "UnityAds", adUnitID: unityAdsAdUnitID),
+        (adapter: "Chartboost", adUnitID: chartboostAdUnitID),
+        (adapter: "AdColony", adUnitID: adColonyAdUnitID),
         (adapter: "Yandex", adUnitID: yandexAdUnitID)
     ]
 

--- a/Examples/YandexMobileAdsExample/YandexMobileAdsExample/Third-PartyMediation/IronSource/IronSourceManager.swift
+++ b/Examples/YandexMobileAdsExample/YandexMobileAdsExample/Third-PartyMediation/IronSource/IronSourceManager.swift
@@ -24,8 +24,8 @@ class IronSourceManager: NSObject {
 
     func initializeSDK() {
         IronSource.setRewardedVideoManualDelegate(self)
-        // Replace 121255e8d with app key generated at https://www.is.com/
-        IronSource.initWithAppKey("121255e8d", adUnits: [IS_INTERSTITIAL, IS_REWARDED_VIDEO])
+        // Replace 199eacc45 with app key generated at https://www.is.com/
+        IronSource.initWithAppKey("199eacc45", adUnits: [IS_INTERSTITIAL, IS_REWARDED_VIDEO])
     }
 }
 

--- a/changelog/adapter/admob-mobileads/CHANGELOG.md
+++ b/changelog/adapter/admob-mobileads/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Version 5.6.0.0
+
+#### Updated
+* Added support for Yandex Mobile Ads SDK 5.6.0
+* Added support for Google Mobile Ads SDK version 10.3.0
+* Updated minimum supported Google Mobile Ads SDK version to 10.3.0
+
 ## Version 5.5.0.0
 
 #### Updated

--- a/changelog/adapter/ironsource-mobileads/CHANGELOG.md
+++ b/changelog/adapter/ironsource-mobileads/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Version 5.6.0.0
+
+### Updated
+* Added support for Yandex Mobile Ads SDK 5.6.0
+* Added support for IronSource SDK 7.3.0.0
+* Updated minimum supported IronSource SDK version to 7.3.0.0
+
 ## Version 5.5.0.0
 
 ### Updated

--- a/changelog/mediation/mobileads-admob/CHANGELOG.md
+++ b/changelog/mediation/mobileads-admob/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Version 10.3.0.0
+
+#### Added
+* Added support for AdMob SDK version 10.3.0
+* Updated minimum supported AdMob SDK version to 10.3.0
+* Updated minimum supported Yandex Mobile Ads SDK version to 5.6.0
+
 ## Version 9.14.0.0
 
 #### Added

--- a/changelog/mediation/mobileads-applovin/CHANGELOG.md
+++ b/changelog/mediation/mobileads-applovin/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Version 11.8.2.0
+
+#### Added
+* Added support for AppLovin sdk version 11.8.2
+* Updated minimum supported AppLovin sdk version to 11.8.2
+* Updated minimum supported Yandex Mobile Ads SDK version to 5.6.0
+
 ## Version 11.6.1.0
 
 #### Added

--- a/changelog/mediation/mobileads-ironsource/CHANGELOG.md
+++ b/changelog/mediation/mobileads-ironsource/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Version 7.3.0.0
+
+#### Updated
+* Added support for IronSource SDK version 7.3.0.0
+* Updated minimum supported IronSource SDK version to 7.3.0.0
+* Updated minimum supported Yandex Mobile Ads SDK version to 5.6.0
+
 ## Version 7.2.7.0
 
 #### Updated

--- a/changelog/mediation/mobileads-mintegral/CHANGELOG.md
+++ b/changelog/mediation/mobileads-mintegral/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Version 7.3.4.0
+
+#### Updated
+* Added support for Mintegral SDK version 7.3.4
+* Updated minimum supported Mintegral SDK version to 7.3.4
+* Updated minimum supported Yandex Mobile Ads SDK version to 5.6.0
+
 ## Version 7.2.9.0
 
 #### Updated

--- a/changelog/mediation/mobileads-mytarget/CHANGELOG.md
+++ b/changelog/mediation/mobileads-mytarget/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Version 5.17.4.0
+
+#### Updated
+* Added support for MyTarget SDK version 5.17.4
+* Updated minimum supported MyTarget SDK version to 5.17.4
+* Updated minimum supported Yandex Mobile Ads SDK version to 5.6.0
+
 ## Version 5.17.2.0
 
 #### Updated

--- a/changelog/mediation/mobileads-unityads/CHANGELOG.md
+++ b/changelog/mediation/mobileads-unityads/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Version 4.6.1.0
+
+#### Updated
+* Added support for UnityAds SDK version 4.6.1
+* Updated minimum supported UnityAds SDK version to 4.6.1
+* Updated minimum supported UnityAds SDK version to 5.6.0
+
 ## Version 4.5.0.0
 
 #### Updated

--- a/changelog/mobileads/CHANGELOG.md
+++ b/changelog/mobileads/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+# Version 5.6.0
+
+SDK archive: [**download**](https://storage.mds.yandex.net/get-ads-mobile-sdk/205984/YandexMobileAds-c50310a7-3eb0-4244-8e6f-5e583e5add19.zip)
+
+#### Added
+* Added improvements and fixes
+* Update adapter versions
+- AppLovinSDK: 11.8.2
+- ChartboostSDK: 9.2.0
+- Google-Mobile-Ads-SDK: 10.3.0
+- IronSourceSDK: 7.3.0.0
+- MintegralAdSDK: 7.3.4
+- UnityAds: 4.6.1
+- myTargetSDK: 5.17.4
+
 # Version 5.5.0
 
 SDK archive: [**download**](https://storage.mds.yandex.net/get-ads-mobile-sdk/205984/YandexMobileAds-a848cd71-27a2-4ad8-8ad0-4edc38499444.zip)
@@ -24,10 +39,8 @@ SDK archive: [**download**](https://storage.mds.yandex.net/get-ads-mobile-sdk/22
 
 # Version 5.3.0
 
-SDK archive: [**download**](https://storage.mds.yandex.net/get-ads-mobile-sdk/205984/YandexMobileAds-5.3.0-ios-12c5720b-942e-404d-ae47-97b9347342d5.zip)
-
+SDK archive: [**download**](https://storage.mds.yandex.net/get-ads-mobile-sdk/205984/YandexMobileAds-5.3.0-ios-4d8e0253-6c04-4003-bccd-d2914835435f.zip)
 #### Added
-* Updated minimum supported version to iOS 12.
 * Added improvements and fixes
 
 # Version 5.2.1


### PR DESCRIPTION
# Version 5.6.0

SDK archive: [**download**](https://storage.mds.yandex.net/get-ads-mobile-sdk/205984/YandexMobileAds-c50310a7-3eb0-4244-8e6f-5e583e5add19.zip)

#### Added
* Added improvements and fixes
* Update adapter versions
  * AppLovinSDK: 11.8.2
  * ChartboostSDK: 9.2.0
  * Google-Mobile-Ads-SDK: 10.3.0
  * IronSourceSDK: 7.3.0.0
  * MintegralAdSDK: 7.3.4
  * UnityAds: 4.6.1
  * myTargetSDK: 5.17.4